### PR TITLE
Simplify unison-pull-request-template

### DIFF
--- a/.github/ISSUE_TEMPLATE/unison-pull-request-template.md
+++ b/.github/ISSUE_TEMPLATE/unison-pull-request-template.md
@@ -1,39 +1,15 @@
 ---
 name: Unison pull request
-about: Use this template for contributions to the Unison base library
+about: Use this for contributing changes to the Unison base library
 labels: pull-request
 ---
 
-> Reminder: Please make your pull request's title more descriptive than "Fix #1203".  Fixed issues can be listed in the "Overview" section.
+Before submitting a pull request, please doublecheck that you have included
 
-> Note: This issue template is for **Unison pull requests** (i.e., contributions to the Unison base library). See [CONTRIBUTING.md](https://github.com/unisonweb/base/blob/master/CONTRIBUTING.md) for detailed instructions. Use the "Tracking issue" template for tracking issues with the base library.
-
-## Overview
-
-What does this change accomplish and why? i.e. How does it change the user experience?
-
-Feel free to include "before and after" examples if appropriate. (You can copy/paste screenshots directly into this editor.)
-
-If relevant, which Github issues does it close? (See [closing-issues-using-keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords).)
-
-## Implementation notes
-
-How does it accomplish it, in broad strokes? i.e. How does it change the Unison codebase?
-
-## Interesting/controversial decisions
-
-Include anything that you thought twice about, debated, chose arbitrarily, etc.
-What could have been done differently, but wasn't? And why?
-
-## Test coverage
-
-Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?
-
-Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?
-
-## Loose ends
-
-Link to related issues that address things you didn't get to. Stuff you encountered on the way and decided not to include in this PR.
+* a clear PR description (don't bother to include issues numbers).
+* `Doc`s linked for types and terms as needed
+* `Author` and `License` metadata linked
+* `Test`s, where appropriate
 
 ## Code review
 


### PR DESCRIPTION
The `unisonweb/unison` template seems overkill for `unison/base` for now.