### PR TITLE
simplify description of `issue-template` template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,6 +1,6 @@
 ---
 name: Tracking issue
-about: Use this template for tracking issues with the Unison base library
+about: Use this for tracking issues with the Unison base library
 ---
 
 > Note: This issue template is for tracking issues with the Unison base library. If you are trying to open a Unison pull request to contribute changes to the base library, please use the "Unison pull request" issue template instead. See [CONTRIBUTING.md](https://github.com/unisonweb/base/blob/master/CONTRIBUTING.md) for detailed instructions.


### PR DESCRIPTION
Probably the user selecting between templates doesn't need to know that they are called "templates".